### PR TITLE
Always emit \n line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Ensure LF line endings across platforms, especially when comparing test fixtures
+*.js text eol=lf

--- a/lib/rewriter.js
+++ b/lib/rewriter.js
@@ -16,7 +16,7 @@ function rewriter(fileInfo, api) {
 
   cleanConsole(j, root);
 
-  return root.toSource();
+  return root.toSource({lineTerminator: '\n'});
 };
 
 module.exports = rewriter;


### PR DESCRIPTION
Previously, the rewriter would use the default, which is to match the operating system. On Windows, the OS uses \r\n by default, instead of \n. This caused problems for me because I use Windows, but I also have set up Git to always produce \n line endings on checkout. In that case, the tests were failing due to mismatched line endings: \n for the fixtures retrieved by Git, and \r\n for the output produced by the rewriter.

The change to rewriter.js ensures that the rewriter always produces \n line endings. The addition of .gitattributes ensures that everyone, even people who have configured their Git to use \r\n by default, always get \n.

Combined, these changes ensure that no matter how your Git is configured, or what operating system you use, only \n line endings will ever show up in this project.