### PR TITLE
Reorder parameters for Reflect_apply

### DIFF
--- a/lib/__testfixtures__/duplicate-imports.output.js
+++ b/lib/__testfixtures__/duplicate-imports.output.js
@@ -2,6 +2,6 @@ import Document, { createElement as Document_createElement, createTextNode as Do
 import { apply as Reflect_apply } from "std:global/Reflect";
 const a = new Document();
 const b = new Document();
-const c = Reflect_apply(a, Document_createElement, ['div']);
-const c2 = Reflect_apply(a, Document_createElement, ['div']);
-const d = Reflect_apply(b, Document_createTextNode, ['test']);
+const c = Reflect_apply(Document_createElement, a, ['div']);
+const c2 = Reflect_apply(Document_createElement, a, ['div']);
+const d = Reflect_apply(Document_createTextNode, b, ['test']);

--- a/lib/__testfixtures__/property-access.output.js
+++ b/lib/__testfixtures__/property-access.output.js
@@ -2,4 +2,4 @@ import { toString as Array_toString } from "std:global/Array";
 import { apply as Reflect_apply } from "std:global/Reflect";
 const a = [1, 2, 3];
 const l = a.length;
-const str = Reflect_apply(a, Array_toString, []);
+const str = Reflect_apply(Array_toString, a, []);

--- a/lib/__testfixtures__/remove-console-all.output.js
+++ b/lib/__testfixtures__/remove-console-all.output.js
@@ -1,7 +1,7 @@
 import { forEach as Array_forEach } from "std:global/Array";
 import { apply as Reflect_apply } from "std:global/Reflect";
 const tips = ['a', 'b', 'c'];
-Reflect_apply(tips, Array_forEach, [(tip, i) => undefined]);
+Reflect_apply(Array_forEach, tips, [(tip, i) => undefined]);
 const v = 5 || undefined;
 if (v) {
 }

--- a/lib/__testfixtures__/remove-console-expressions.output.js
+++ b/lib/__testfixtures__/remove-console-expressions.output.js
@@ -1,7 +1,7 @@
 import { forEach as Array_forEach } from "std:global/Array";
 import { apply as Reflect_apply } from "std:global/Reflect";
 const arr = [1, 2, 3];
-Reflect_apply(arr, Array_forEach, [elt => undefined]);
+Reflect_apply(Array_forEach, arr, [elt => undefined]);
 if (null || undefined) {
     const a = 5 || undefined;
 }

--- a/lib/mods/replace-methods.js
+++ b/lib/mods/replace-methods.js
@@ -20,7 +20,7 @@ const {
 function formatCall(base, original, args, type) {
   switch (type) {
     case 'method':
-      return `Reflect_apply(${base}, ${original}, [${args}])`;
+      return `Reflect_apply(${original}, ${base}, [${args}])`;
     case 'static':
       return `${original}(${args})`;
     default:


### PR DESCRIPTION
The `apply` function takes the function as the first parameter and the callee as the second, but I had those mixed up previously, so this PR is a fix for that.