### PR TITLE
Fix the integration test when running on Windows

### DIFF
--- a/lib/__tests__/test.js
+++ b/lib/__tests__/test.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const {walkDir} = require('../execution-helper');
 const rewriter = require('../rewriter');
-const {execSync} = require('child_process');
+const {execFileSync} = require('child_process');
 
 const integrationInput = fs.readFileSync(
     './lib/__testfixtures__/static-methods.input.mjs', 'utf8'
@@ -18,16 +18,16 @@ const integrationOutput = fs.readFileSync(
  */
 function runIntegrationTest() {
   test('the rewriter command overwrites input file with correct output', () => {
-    const path = './integration.js';
+    const tempFilePath = './integration.js';
     try {
-      fs.writeFileSync(path, integrationInput, 'utf8');
+      fs.writeFileSync(tempFilePath, integrationInput, 'utf8');
 
-      execSync(`./bin/rewrite.js ${path}`);
-      const fileOutput = fs.readFileSync(path, 'utf8');
+      execFileSync(process.argv[0], ['./bin/rewrite.js', tempFilePath]);
+      const fileOutput = fs.readFileSync(tempFilePath, 'utf8');
 
       expect(fileOutput).toEqual(integrationOutput);
     } finally {
-      fs.unlinkSync(path);
+      fs.unlinkSync(tempFilePath);
     }
   });
 }


### PR DESCRIPTION
Windows does not have the same ability to treat .js files as executable, so you need to prefix with the "node" executable (i.e. with process.argv[0]). This is most easily done (without escaping spaces, etc.) by using execFileSync instead of execSync.