### PR TITLE
Explicitly set ScriptKind to JS

### DIFF
--- a/lib/rewriter.js
+++ b/lib/rewriter.js
@@ -36,7 +36,10 @@ function rewriter(fileInfo) {
       // rewriter always handles single-file projects.
       fileInfo.path + '.js',
       fileInfo.source,
-      {overwrite: true},
+      {
+        overwrite: true,
+        scriptKind: ts.ScriptKind.JS,
+      },
   );
 
   const imports = {};


### PR DESCRIPTION
Since we've been operating under the assumption that the rewriter has the information as the TS-AST-viewer when given ScriptKind `ts.ScriptKind.JS` I thought it would make sense to make that assumption explicit.