### PR TITLE
Refactor type retrieval

### DIFF
--- a/lib/originals-helper.js
+++ b/lib/originals-helper.js
@@ -52,7 +52,7 @@ function getModuleNameForType(type) {
  * type. (This is sometimes different from the TypeScript type name.)
  */
 function getModuleNameForPropertyOfNode(node, property) {
-  const type = node.getType().getApparentType();
+  const type = node.getType();
 
   // Find the deepest reference to the property in the prototype chain
   let inspectType = type;


### PR DESCRIPTION
Currently `getModuleNameForType` is explicitly checking for literal values, but while I was digging though the documentation I found the `.getApparentType()` method, which turns literal types into their apparent counterpart (e.g. `4` into `Number`)

https://ts-morph.com/details/types